### PR TITLE
Remove ratingView from the collection

### DIFF
--- a/app/collections/Album.js
+++ b/app/collections/Album.js
@@ -8,12 +8,14 @@ var Album = Backbone.Collection.extend({
   initialize: function() {
     new ListView({model: this});
     // this.on('updateRating', this.setRating);
-    this.on('change:rating', this.setPhotoRating);
+    // this.on('change:rating', this.setPhotoRating);
     // new RatingView({model: this});
+
   },
   setPhotoRating: function(rating) {
     var that = this;
     this.each(function(photo){
+      console.log("setPhotoRating called inside collection");
       if(photo.title = that.get('title')){
         photo.set('rating', that.get('rating'));
       }

--- a/app/models/Photo.js
+++ b/app/models/Photo.js
@@ -10,25 +10,38 @@ var Photo = Backbone.Model.extend({
   initialize: function() {
     // initialize rating view in the collection
     // new RatingView({model: this});
+    // this.bind('change', this.attributesChanged);
     new OrderCountView({model: this});
   },
 
+  // attributesChanged: function() {
+  //       this.set('rating', rating);
+
+  //   var changedRating = this.get('rating');
+  //   this.trigger('changed', changedRating);
+  // }
+
   updateView: function() {
     new PhotoView({model: this});
+    this.set('title', this.attributes.title);
+    console.log(this.attributes.title);
+    // console.log(this);
     new RatingView({model: this});
 
-    this.trigger('updatePhotoView', this);
+    // this.trigger('updatePhotoView', this);
 
     // this.set('rating', this.get('rating'));
 
-    this.trigger('updateRating', this);
+    // this.trigger('updateRating', this);
   },
+
+  // updateRating: function
 
   setRating: function(rating, title) {
     // console.log('rating passed to model: ' + rating);
-    console.log('title inside model setRating', title);
+    // console.log('title inside model setRating', title);
     this.set('rating', rating);
-        console.log('rating inside model setRating', rating);
+        console.log('title and rating', title, rating);
 
     // this.trigger('emitRating', this);
     // this.set('title', title);

--- a/app/views/ListItemView.js
+++ b/app/views/ListItemView.js
@@ -13,6 +13,7 @@ var ListItemView = Backbone.View.extend({
 
   broadcastClick: function() {
     this.model.updateView();
+    this.model.setRating();
   },
 
   render: function(){

--- a/app/views/RatingItemView.js
+++ b/app/views/RatingItemView.js
@@ -1,0 +1,3 @@
+var RatingItemView = Backbone.View.extend({
+
+});

--- a/app/views/RatingView.js
+++ b/app/views/RatingView.js
@@ -1,5 +1,5 @@
 var RatingView = Backbone.View.extend({
-  collection: Album,
+  // collection: Album,
   // model: Photo,
   // el: $('.dropdown-menu a'),
     // el: $('.photo-area'),
@@ -12,7 +12,13 @@ var RatingView = Backbone.View.extend({
     'click': 'updateRating'
   },
 
+  initialize: function() {
+    this.model.bind("ratingUpdated", this.updateRating);
+  },
+
+
   updateRating: function(e) {
+    // e.preventDefault();
     var $target = $(e.currentTarget);
     // console.log(this.model)
     // console.log($target);
@@ -22,8 +28,9 @@ var RatingView = Backbone.View.extend({
           .children('.dropdown-toggle').dropdown('toggle');
           // console.log($target.text());
     // return $target.html();
+    // this.model.set({rating: $target.text()});
     this.model.setRating($target.text(), this.model.get('title'));
-    console.log('model title', this.model.get('title'));
+    // console.log('model title', this.model.get('title'));
   }
 
 });


### PR DESCRIPTION
Current behavior: Rating is bound to each photo in the collection every time you change the rating for any individual photo. (When you change the rating for any one photo, that new rating is bound to every photo in the collection.)
Expected behavior: Rating should only be bound to the photo that is displayed in the photo view when the rating is changed.
